### PR TITLE
Add GitHub Copilot provider via copilot-api

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,11 @@ The main plugin lives in @zsh-ai-cmd.plugin.zsh with provider implementations in
  | Gemini     | `providers/gemini.zsh`    | `gemini-3-flash-preview`    | `GEMINI_API_KEY`    |
  | DeepSeek   | `providers/deepseek.zsh`  | `deepseek-chat`             | `DEEPSEEK_API_KEY`  |
  | Ollama     | `providers/ollama.zsh`    | `mistral-small`             | (none - local)      |
+ | Copilot    | `providers/copilot.zsh`   | `gpt-4o`                    | (none - local)      |
 
 Set provider via `ZSH_AI_CMD_PROVIDER='openai'` (default: `anthropic`).
+
+**Note:** Copilot requires [copilot-api](https://github.com/ericc-ch/copilot-api) to be running. Install and start with `npx copilot-api start`.
 
 ### Provider Implementation
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ZSH_AI_CMD_GEMINI_MODEL='gemini-3-flash-preview'
 ZSH_AI_CMD_DEEPSEEK_MODEL='deepseek-chat'
 ZSH_AI_CMD_OLLAMA_MODEL='mistral-small'
 ZSH_AI_CMD_COPILOT_MODEL='gpt-4o'           # Requires copilot-api (npx copilot-api start)
-ZSH_AI_CMD_COPILOT_HOST='localhost:9191'    # copilot-api endpoint
+ZSH_AI_CMD_COPILOT_HOST='localhost:4141'    # copilot-api endpoint
 ```
 
 ## Provider Comparison

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ git clone https://github.com/kylesnowschwartz/zsh-ai-cmd ~/.zsh-ai-cmd
 source ~/.zsh-ai-cmd/zsh-ai-cmd.plugin.zsh
 
 # Choose your provider (default: anthropic)
-export ZSH_AI_CMD_PROVIDER='anthropic'  # or: openai, gemini, deepseek, ollama
+export ZSH_AI_CMD_PROVIDER='anthropic'  # or: openai, gemini, deepseek, ollama, copilot
 
 # Set API key for your chosen provider
 export ANTHROPIC_API_KEY='sk-ant-...'
 export OPENAI_API_KEY='sk-...'
 export GEMINI_API_KEY='...'
 export DEEPSEEK_API_KEY='sk-...'
-# Ollama needs no key (local)
+# Ollama and Copilot need no key (local services)
 
 # Or use macOS Keychain
 security add-generic-password -s 'anthropic-api-key' -a "$USER" -w 'sk-ant-...'
@@ -39,7 +39,7 @@ security add-generic-password -s 'anthropic-api-key' -a "$USER" -w 'sk-ant-...'
 ## Configuration
 
 ```sh
-ZSH_AI_CMD_PROVIDER='anthropic'              # Provider: anthropic, openai, gemini, deepseek, ollama
+ZSH_AI_CMD_PROVIDER='anthropic'              # Provider: anthropic, openai, gemini, deepseek, ollama, copilot
 ZSH_AI_CMD_KEY='^z'                          # Trigger key (default: Ctrl+Z)
 ZSH_AI_CMD_HIGHLIGHT='fg=8'                  # Ghost text style (zsh region_highlight format)
 ZSH_AI_CMD_DEBUG=false                       # Enable debug logging
@@ -51,11 +51,15 @@ ZSH_AI_CMD_OPENAI_MODEL='gpt-5.2-2025-12-11'
 ZSH_AI_CMD_GEMINI_MODEL='gemini-3-flash-preview'
 ZSH_AI_CMD_DEEPSEEK_MODEL='deepseek-chat'
 ZSH_AI_CMD_OLLAMA_MODEL='mistral-small'
+ZSH_AI_CMD_COPILOT_MODEL='gpt-4o'           # Requires copilot-api (npx copilot-api start)
+ZSH_AI_CMD_COPILOT_HOST='localhost:9191'    # copilot-api endpoint
 ```
 
 ## Provider Comparison
 
 All providers pass the test suite (19/19). Full output comparison:
+
+**Note:** Copilot provider requires [copilot-api](https://github.com/ericc-ch/copilot-api) to be running locally. Install and start with `npx copilot-api start`.
 
 <details>
 <summary>Click to expand full comparison table</summary>

--- a/providers/copilot.zsh
+++ b/providers/copilot.zsh
@@ -2,7 +2,7 @@
 # Uses OpenAI-compatible endpoint. No API key required (copilot-api handles GitHub OAuth).
 
 typeset -g ZSH_AI_CMD_COPILOT_MODEL=${ZSH_AI_CMD_COPILOT_MODEL:-'gpt-4o'}
-typeset -g ZSH_AI_CMD_COPILOT_HOST=${ZSH_AI_CMD_COPILOT_HOST:-'localhost:9191'}
+typeset -g ZSH_AI_CMD_COPILOT_HOST=${ZSH_AI_CMD_COPILOT_HOST:-'localhost:4141'}
 
 _zsh_ai_cmd_copilot_call() {
   local input=$1

--- a/providers/copilot.zsh
+++ b/providers/copilot.zsh
@@ -1,0 +1,86 @@
+# providers/copilot.zsh - GitHub Copilot via copilot-api proxy
+# Uses OpenAI-compatible endpoint. No API key required (copilot-api handles GitHub OAuth).
+
+typeset -g ZSH_AI_CMD_COPILOT_MODEL=${ZSH_AI_CMD_COPILOT_MODEL:-'gpt-4o'}
+typeset -g ZSH_AI_CMD_COPILOT_HOST=${ZSH_AI_CMD_COPILOT_HOST:-'localhost:9191'}
+
+_zsh_ai_cmd_copilot_call() {
+  local input=$1
+  local prompt=$2
+
+  local payload
+  payload=$(command jq -nc \
+    --arg model "$ZSH_AI_CMD_COPILOT_MODEL" \
+    --arg system "$prompt" \
+    --arg content "$input" \
+    '{
+      model: $model,
+      max_completion_tokens: 256,
+      messages: [
+        {role: "system", content: $system},
+        {role: "user", content: $content}
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "shell_command",
+          schema: {
+            type: "object",
+            properties: {
+              command: {type: "string", description: "The shell command"}
+            },
+            required: ["command"],
+            additionalProperties: false
+          },
+          strict: true
+        }
+      }
+    }')
+
+  local response
+  response=$(command curl -sS --max-time 30 "http://${ZSH_AI_CMD_COPILOT_HOST}/v1/chat/completions" \
+    -H "Content-Type: application/json" \
+    -d "$payload" 2>/dev/null)
+
+  # Debug log
+  if [[ $ZSH_AI_CMD_DEBUG == true ]]; then
+    {
+      print -- "=== $(date '+%Y-%m-%d %H:%M:%S') [copilot] ==="
+      print -- "--- REQUEST ---"
+      command jq . <<< "$payload"
+      print -- "--- RESPONSE ---"
+      command jq . <<< "$response"
+      print ""
+    } >>$ZSH_AI_CMD_LOG
+  fi
+
+  # Check for API error (OpenAI format: {"error": {"message": "..."}})
+  local error_msg
+  error_msg=$(print -r -- "$response" | command jq -re '.error.message // empty' 2>/dev/null)
+  if [[ -n $error_msg ]]; then
+    print -u2 "zsh-ai-cmd [copilot]: $error_msg"
+    return 1
+  fi
+
+  # Extract command from response
+  print -r -- "$response" | command jq -re '.choices[0].message.content | fromjson | .command // empty' 2>/dev/null
+}
+
+_zsh_ai_cmd_copilot_key_error() {
+  # Copilot doesn't need an API key, but copilot-api server must be running
+  print -u2 ""
+  print -u2 "zsh-ai-cmd: Cannot connect to copilot-api at ${ZSH_AI_CMD_COPILOT_HOST}"
+  print -u2 ""
+  print -u2 "Make sure copilot-api is installed and running:"
+  print -u2 "  npx copilot-api start"
+  print -u2 ""
+  print -u2 "Or set a custom host:"
+  print -u2 "  export ZSH_AI_CMD_COPILOT_HOST='localhost:8080'"
+  print -u2 ""
+  print -u2 "Learn more: https://github.com/ericc-ch/copilot-api"
+}
+
+# Check if copilot-api is available (used for validation)
+_zsh_ai_cmd_copilot_available() {
+  command curl -sS --max-time 2 "http://${ZSH_AI_CMD_COPILOT_HOST}/v1/models" >/dev/null 2>&1
+}

--- a/test-api.sh
+++ b/test-api.sh
@@ -169,6 +169,7 @@ get_model_name() {
     ollama)    print "$ZSH_AI_CMD_OLLAMA_MODEL" ;;
     deepseek)  print "$ZSH_AI_CMD_DEEPSEEK_MODEL" ;;
     gemini)    print "$ZSH_AI_CMD_GEMINI_MODEL" ;;
+    copilot)   print "$ZSH_AI_CMD_COPILOT_MODEL" ;;
   esac
 }
 

--- a/test-api.sh
+++ b/test-api.sh
@@ -127,6 +127,7 @@ PWD: /tmp/test
     ollama)    _zsh_ai_cmd_ollama_call "$input" "$prompt" ;;
     deepseek)  _zsh_ai_cmd_deepseek_call "$input" "$prompt" ;;
     gemini)    _zsh_ai_cmd_gemini_call "$input" "$prompt" ;;
+    copilot)   _zsh_ai_cmd_copilot_call "$input" "$prompt" ;;
     *) print -u2 "Unknown provider: $ZSH_AI_CMD_PROVIDER"; return 1 ;;
   esac
 }

--- a/test-api.sh
+++ b/test-api.sh
@@ -11,7 +11,7 @@ typeset -g ZSH_AI_CMD_PROVIDER=${ZSH_AI_CMD_PROVIDER:-'anthropic'}
 while [[ $# -gt 0 ]]; do
   case $1 in
     --provider|-p) ZSH_AI_CMD_PROVIDER=$2; shift 2 ;;
-    --help|-h) print "Usage: $0 [--provider anthropic|openai|ollama|deepseek|gemini]"; exit 0 ;;
+    --help|-h) print "Usage: $0 [--provider anthropic|openai|ollama|deepseek|gemini|copilot]"; exit 0 ;;
     *) print -u2 "Unknown option: $1"; exit 1 ;;
   esac
 done
@@ -35,13 +35,14 @@ source "${SCRIPT_DIR}/providers/openai.zsh"
 source "${SCRIPT_DIR}/providers/ollama.zsh"
 source "${SCRIPT_DIR}/providers/deepseek.zsh"
 source "${SCRIPT_DIR}/providers/gemini.zsh"
+source "${SCRIPT_DIR}/providers/copilot.zsh"
 
 # Get API key for current provider
 get_api_key() {
   local provider=$ZSH_AI_CMD_PROVIDER
 
-  # Ollama doesn't need a key
-  [[ $provider == ollama ]] && return 0
+  # Ollama and Copilot don't need a key
+  [[ $provider == ollama || $provider == copilot ]] && return 0
 
   local key_var="${(U)provider}_API_KEY"
   local keychain_name="${provider}-api-key"

--- a/zsh-ai-cmd.plugin.zsh
+++ b/zsh-ai-cmd.plugin.zsh
@@ -78,6 +78,7 @@ source "${0:a:h}/providers/openai.zsh"
 source "${0:a:h}/providers/ollama.zsh"
 source "${0:a:h}/providers/deepseek.zsh"
 source "${0:a:h}/providers/gemini.zsh"
+source "${0:a:h}/providers/copilot.zsh"
 
 # ============================================================================
 # Ghost Text Display
@@ -199,6 +200,7 @@ _zsh_ai_cmd_call_api() {
     ollama)    _zsh_ai_cmd_ollama_call "$input" "$prompt" ;;
     deepseek)  _zsh_ai_cmd_deepseek_call "$input" "$prompt" ;;
     gemini)    _zsh_ai_cmd_gemini_call "$input" "$prompt" ;;
+    copilot)   _zsh_ai_cmd_copilot_call "$input" "$prompt" ;;
     *) print -u2 "zsh-ai-cmd: Unknown provider '$ZSH_AI_CMD_PROVIDER'"; return 1 ;;
   esac
 }
@@ -311,8 +313,8 @@ fi
 _zsh_ai_cmd_get_key() {
   local provider=$ZSH_AI_CMD_PROVIDER
 
-  # Ollama doesn't need a key
-  [[ $provider == ollama ]] && return 0
+  # Ollama and Copilot don't need a key
+  [[ $provider == ollama || $provider == copilot ]] && return 0
 
   local key_var="${(U)provider}_API_KEY"
   local keychain_name="${provider}-api-key"


### PR DESCRIPTION
## Summary
Adds GitHub Copilot as a new provider using the [copilot-api](https://github.com/ericc-ch/copilot-api) proxy server, which exposes GitHub Copilot as an OpenAI-compatible API endpoint.

## Changes
- **New provider**: `providers/copilot.zsh` (86 lines)
  - Uses OpenAI-compatible `/v1/chat/completions` endpoint
  - Strict JSON schema for deterministic command extraction
  - No API key required (copilot-api handles GitHub OAuth)
  - Configurable model and host
- **Main plugin**: Updated with copilot provider integration
- **Documentation**: Updated CLAUDE.md and README.md with setup instructions
- **Tests**: Full test suite integration (19/19 tests passing)

## Prerequisites
Requires [copilot-api](https://github.com/ericc-ch/copilot-api) to be running locally:
```sh
npx copilot-api start
```

This will authenticate with GitHub using OAuth device flow on first run.

## Configuration
```sh
# Minimal setup
export ZSH_AI_CMD_PROVIDER='copilot'

# Optional customization
export ZSH_AI_CMD_COPILOT_MODEL='gpt-4o'        # Default: gpt-4o
export ZSH_AI_CMD_COPILOT_HOST='localhost:4141' # Default: localhost:4141
```

## Available Models
Depends on your GitHub Copilot subscription:
- `gpt-4o` (recommended, default)
- `gpt-4o-mini` (faster, lower cost)
- `o1-mini` (reasoning model)
- Others based on subscription tier

## Testing
All 19 test cases pass:
```sh
./test-api.sh --provider copilot
# Results: 19 passed, 0 failed
```

## Implementation Notes
- Follows the same architecture as existing providers (OpenAI, Ollama, etc.)
- OpenAI-compatible request/response format
- Local service model (like Ollama) - no cloud API key needed
- copilot-api handles all GitHub authentication automatically
- Default port 4141 matches copilot-api standard