### PR TITLE
Added ZSH_AI_CMD_KEYCHAIN_NAME.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ ZSH_AI_CMD_HIGHLIGHT='fg=8'                  # Ghost text style (zsh region_high
 ZSH_AI_CMD_DEBUG=false                       # Enable debug logging
 ZSH_AI_CMD_LOG=/tmp/zsh-ai-cmd.log           # Debug log path
 
+# macOS Keychain lookup (${provider} is interpolated at runtime)
+ZSH_AI_CMD_KEYCHAIN_NAME='${provider}-api-key'  # Or use a fixed name: 'my-api-key'
+
 # Provider-specific models (defaults shown)
 ZSH_AI_CMD_ANTHROPIC_MODEL='claude-haiku-4-5-20251001'
 ZSH_AI_CMD_OPENAI_MODEL='gpt-5.2-2025-12-11'

--- a/test-api.sh
+++ b/test-api.sh
@@ -45,7 +45,7 @@ get_api_key() {
   [[ $provider == ollama || $provider == copilot ]] && return 0
 
   local key_var="${(U)provider}_API_KEY"
-  local keychain_name="${provider}-api-key"
+  local keychain_name="${(e)ZSH_AI_CMD_KEYCHAIN_NAME:-${provider}-api-key}"
 
   # Check env var (use :- to avoid set -u error)
   [[ -n ${(P)key_var:-} ]] && return 0

--- a/zsh-ai-cmd.plugin.zsh
+++ b/zsh-ai-cmd.plugin.zsh
@@ -13,6 +13,9 @@ typeset -g ZSH_AI_CMD_KEY=${ZSH_AI_CMD_KEY:-'^z'}
 typeset -g ZSH_AI_CMD_DEBUG=${ZSH_AI_CMD_DEBUG:-false}
 typeset -g ZSH_AI_CMD_LOG=${ZSH_AI_CMD_LOG:-/tmp/zsh-ai-cmd.log}
 typeset -g ZSH_AI_CMD_HIGHLIGHT=${ZSH_AI_CMD_HIGHLIGHT:-'fg=8'}
+
+# Keychain entry name for API key lookup. Single quotes delay ${provider} expansion
+# until _zsh_ai_cmd_get_key() runs. Override with a literal name if needed.
 typeset -g ZSH_AI_CMD_KEYCHAIN_NAME=${ZSH_AI_CMD_KEYCHAIN_NAME:-'${provider}-api-key'}
 
 # Provider selection (anthropic, openai, gemini, deepseek, ollama)

--- a/zsh-ai-cmd.plugin.zsh
+++ b/zsh-ai-cmd.plugin.zsh
@@ -13,6 +13,7 @@ typeset -g ZSH_AI_CMD_KEY=${ZSH_AI_CMD_KEY:-'^z'}
 typeset -g ZSH_AI_CMD_DEBUG=${ZSH_AI_CMD_DEBUG:-false}
 typeset -g ZSH_AI_CMD_LOG=${ZSH_AI_CMD_LOG:-/tmp/zsh-ai-cmd.log}
 typeset -g ZSH_AI_CMD_HIGHLIGHT=${ZSH_AI_CMD_HIGHLIGHT:-'fg=8'}
+typeset -g ZSH_AI_CMD_KEYCHAIN_NAME=${ZSH_AI_CMD_KEYCHAIN_NAME:-'${provider}-api-key'}
 
 # Provider selection (anthropic, openai, gemini, deepseek, ollama)
 typeset -g ZSH_AI_CMD_PROVIDER=${ZSH_AI_CMD_PROVIDER:-'anthropic'}
@@ -317,7 +318,7 @@ _zsh_ai_cmd_get_key() {
   [[ $provider == ollama || $provider == copilot ]] && return 0
 
   local key_var="${(U)provider}_API_KEY"
-  local keychain_name="${provider}-api-key"
+  local keychain_name="${(e)ZSH_AI_CMD_KEYCHAIN_NAME}"
 
   # Check env var
   [[ -n ${(P)key_var} ]] && return 0


### PR DESCRIPTION
Right now the assumption is that the provider API key is always stored under `<provider>-api-key` in the keychain. I already have my API key stored in keychain under another name, so allow this property to be customized using an environmental variable.