### PR TITLE
feat: add LMStudio provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to zsh-ai-cmd are documented in this file.
 
+
+## [v0.3.0] - 2026-06-08
+
+### Added
+- **LM Studio Provider** (`ZSH_AI_CMD_PROVIDER='lmstudio'`)
+  - Local inference via LM Studio's OpenAI-compatible API server
+  - No API key required — runs entirely on your machine
+  - Configurable host via `ZSH_AI_CMD_LMSTUDIO_HOST` (default: `localhost:1234`)
+  - Configurable model via `ZSH_AI_CMD_LMSTUDIO_MODEL` (default: `qwen2.5.1-coder-7b-instruct`)
+  - Structured JSON output via `response_format` for reliable command extraction
+  - `--max-time 60` on completion curl to prevent terminal hangs on stalled models
+  - Error handling for API error responses (model not loaded, unsupported format, etc.)
+
+### Configuration
+```sh
+export ZSH_AI_CMD_PROVIDER='lmstudio'
+
+# Optional: change default model
+export ZSH_AI_CMD_LMSTUDIO_MODEL='qwen2.5.1-coder-7b-instruct'
+
+# Optional: custom host/port
+export ZSH_AI_CMD_LMSTUDIO_HOST='localhost:1234'
+```
+
+### How to Test
+1. Install [LM Studio](https://lmstudio.ai/) and download any GGUF model
+2. Start the local server: click **"Start Server"** in the left sidebar (default `localhost:1234`)
+3. In your terminal:
+   ```sh
+   export ZSH_AI_CMD_PROVIDER='lmstudio'
+   source ./zsh-ai-cmd.plugin.zsh
+   # Type natural language, press Ctrl+Z
+   list files modified today<Ctrl+Z>
+   ```
+4. Run automated validation:
+   ```sh
+   ./test-api.sh --provider lmstudio
+   ```
+
+### Testing
+- Added lmstudio to `test-api.sh` provider list and test dispatch
+- Error handling verified: API error responses (e.g., model not loaded) are surfaced to the user with a clear message instead of silently producing empty suggestions
+
+---
+
 ## [v0.2.0] - 2026-04-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,15 +12,16 @@ The main plugin lives in @zsh-ai-cmd.plugin.zsh with provider implementations in
 
 ### Supported Providers
 
- | Provider   | File                      | Default Model               | API Key Env Var     | Custom Endpoint Var           |
- | ---------- | ------                    | ---------------             | -----------------   | -------------------           |
- | Anthropic  | `providers/anthropic.zsh` | `claude-haiku-4-5-20251001` | `ANTHROPIC_API_KEY` |                               |
- | OpenAI     | `providers/openai.zsh`    | `gpt-5.2-2025-12-11`        | `OPENAI_API_KEY`    | `ZSH_AI_CMD_OPENAI_BASE_URL`  |
- | Gemini     | `providers/gemini.zsh`    | `gemini-3-flash-preview`    | `GEMINI_API_KEY`    |                               |
- | DeepSeek   | `providers/deepseek.zsh`  | `deepseek-chat`             | `DEEPSEEK_API_KEY`  |                               |
- | Ollama     | `providers/ollama.zsh`    | `mistral-small`             | (none - local)      | `ZSH_AI_CMD_OLLAMA_HOST`      |
- | Copilot    | `providers/copilot.zsh`   | `gpt-4o`                    | (none - local)      | `ZSH_AI_CMD_COPILOT_HOST`     |
- | Claude Code | `providers/claude-code.zsh` | (CLI default)            | (none - subscription) |                             |
+ | Provider   | File                      | Default Model                  | API Key Env Var     | Custom Endpoint Var           |
+ | ---------- | ------                    | ---------------                | -----------------   | -------------------           |
+ | Anthropic  | `providers/anthropic.zsh` | `claude-haiku-4-5-20251001`    | `ANTHROPIC_API_KEY` |                               |
+ | OpenAI     | `providers/openai.zsh`    | `gpt-5.2-2025-12-11`           | `OPENAI_API_KEY`    | `ZSH_AI_CMD_OPENAI_BASE_URL`  |
+ | Gemini     | `providers/gemini.zsh`    | `gemini-3-flash-preview`       | `GEMINI_API_KEY`    |                               |
+ | DeepSeek   | `providers/deepseek.zsh`  | `deepseek-chat`                | `DEEPSEEK_API_KEY`  |                               |
+ | Ollama     | `providers/ollama.zsh`    | `mistral-small`                | (none - local)      | `ZSH_AI_CMD_OLLAMA_HOST`      |
+ | LMStudio   | `providers/lmstudio.zsh`  | `qwen2.5.1-coder-7b-instruct ` | (none - local)      | `ZSH_AI_CMD_LMSTUDIO_HOST`    |
+ | Copilot    | `providers/copilot.zsh`   | `gpt-4o`                       | (none - local)      | `ZSH_AI_CMD_COPILOT_HOST`     |
+ | Claude Code | `providers/claude-code.zsh` | (CLI default)               | (none - subscription) |                             |
 
 Set provider via `ZSH_AI_CMD_PROVIDER='openai'` (default: `anthropic`).
 
@@ -77,6 +78,7 @@ API response validation tests live in @test-api.sh:
 ./test-api.sh --provider openai
 ./test-api.sh --provider gemini
 ./test-api.sh --provider ollama
+./test-api.sh --provider lmstudio
 ./test-api.sh --provider deepseek
 ```
 

--- a/providers/lmstudio.zsh
+++ b/providers/lmstudio.zsh
@@ -1,0 +1,87 @@
+# providers/lmstudio.zsh - LM Studio local inference provider
+# No API key required, runs locally. 
+
+typeset -g ZSH_AI_CMD_LMSTUDIO_MODEL=${ZSH_AI_CMD_LMSTUDIO_MODEL:-'meta-llama-3-8b-instruct'}
+typeset -g ZSH_AI_CMD_LMSTUDIO_HOST=${ZSH_AI_CMD_LMSTUDIO_HOST:-'localhost:1234'}
+
+_zsh_ai_cmd_lmstudio_key_error() {
+  print "Error: LM Studio provider configurations missing." >&2
+  print "Ensure ZSH_AI_CMD_LMSTUDIO_HOST is correct." >&2
+  return 1
+}
+
+_zsh_ai_cmd_lmstudio_available() {
+  if [[ -z "$ZSH_AI_CMD_LMSTUDIO_HOST" ]]; then
+    return 1
+  fi
+
+  command curl -s -m 2 "http://$ZSH_AI_CMD_LMSTUDIO_HOST/v1/models" >/dev/null 2>&1
+}
+
+_zsh_ai_cmd_lmstudio_call() {
+  local input="$1"
+  local prompt="$2"
+
+  if [[ -z "$ZSH_AI_CMD_LMSTUDIO_HOST" ]]; then
+    _zsh_ai_cmd_lmstudio_key_error
+    return 1
+  fi
+
+  local payload
+  payload=$(command jq -nc \
+    --arg model "$ZSH_AI_CMD_LMSTUDIO_MODEL" \
+    --arg system "$prompt" \
+    --arg content "$input" \
+    '{
+      model: $model,
+      messages: [
+        {role: "system", content: $system},
+        {role: "user", content: $content}
+      ],
+      stream: false,
+      response_format: {
+        type: "json_schema",
+        json_schema: {
+          name: "shell_command",
+          strict: true,
+          schema: {
+            type: "object",
+            properties: {
+              command: {type: "string", description: "The shell command"}
+            },
+            required: ["command"],
+            additionalProperties: false
+          }
+        }
+      }
+    }')
+
+  local response
+  response=$(command curl -sS \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "http://$ZSH_AI_CMD_LMSTUDIO_HOST/v1/chat/completions" 2>/dev/null)
+
+  if [[ $? -ne 0 || -z "$response" ]]; then
+    print "Error: Failed to connect to LM Studio at $ZSH_AI_CMD_LMSTUDIO_HOST" >&2
+    return 1
+  fi
+
+  # Debug log
+  if [[ $ZSH_AI_CMD_DEBUG == true ]]; then
+    {
+      print -- "=== $(date '+%Y-%m-%d %H:%M:%S') [lmstudio] ==="
+      print -- "--- REQUEST ---"
+      command jq . <<< "$payload"
+      print -- "--- RESPONSE ---"
+      command jq . <<< "$response"
+      print ""
+    } >>$ZSH_AI_CMD_LOG
+  fi
+
+  local command_output
+  command_output=$(print "$response" | command jq -r '.choices[0].message.content // empty' 2>/dev/null)
+
+  print -r -- "$response" | command jq -re '.choices[0].message.content | fromjson | .command // empty' 2>/dev/null
+}

--- a/providers/lmstudio.zsh
+++ b/providers/lmstudio.zsh
@@ -1,12 +1,12 @@
 # providers/lmstudio.zsh - LM Studio local inference provider
 # No API key required, runs locally. 
 
-typeset -g ZSH_AI_CMD_LMSTUDIO_MODEL=${ZSH_AI_CMD_LMSTUDIO_MODEL:-'meta-llama-3-8b-instruct'}
+typeset -g ZSH_AI_CMD_LMSTUDIO_MODEL=${ZSH_AI_CMD_LMSTUDIO_MODEL:-'qwen2.5.1-coder-7b-instruct'}
 typeset -g ZSH_AI_CMD_LMSTUDIO_HOST=${ZSH_AI_CMD_LMSTUDIO_HOST:-'localhost:1234'}
 
 _zsh_ai_cmd_lmstudio_key_error() {
-  print "Error: LM Studio provider configurations missing." >&2
-  print "Ensure ZSH_AI_CMD_LMSTUDIO_HOST is correct." >&2
+  print -u2 "Error: LM Studio provider configurations missing." >&2
+  print -u2 "Ensure ZSH_AI_CMD_LMSTUDIO_HOST is correct." >&2
   return 1
 }
 
@@ -15,7 +15,7 @@ _zsh_ai_cmd_lmstudio_available() {
     return 1
   fi
 
-  command curl -s -m 2 "http://$ZSH_AI_CMD_LMSTUDIO_HOST/v1/models" >/dev/null 2>&1
+  command curl -sS --max-time 2 "http://$ZSH_AI_CMD_LMSTUDIO_HOST/v1/models" >/dev/null 2>&1
 }
 
 _zsh_ai_cmd_lmstudio_call() {
@@ -57,16 +57,10 @@ _zsh_ai_cmd_lmstudio_call() {
     }')
 
   local response
-  response=$(command curl -sS \
-    -X POST \
+  response=$(command curl -sS --max-time 60 -X POST \
     -H "Content-Type: application/json" \
     -d "$payload" \
     "http://$ZSH_AI_CMD_LMSTUDIO_HOST/v1/chat/completions" 2>/dev/null)
-
-  if [[ $? -ne 0 || -z "$response" ]]; then
-    print "Error: Failed to connect to LM Studio at $ZSH_AI_CMD_LMSTUDIO_HOST" >&2
-    return 1
-  fi
 
   # Debug log
   if [[ $ZSH_AI_CMD_DEBUG == true ]]; then
@@ -80,8 +74,13 @@ _zsh_ai_cmd_lmstudio_call() {
     } >>$ZSH_AI_CMD_LOG
   fi
 
-  local command_output
-  command_output=$(print "$response" | command jq -r '.choices[0].message.content // empty' 2>/dev/null)
+  # Check for API error (OpenAI format: {"error": {"message": "..."}})
+  local error_msg
+  error_msg=$(print -r -- "$response" | command jq -re '.error.message // empty' 2>/dev/null)
+  if [[ -n $error_msg ]]; then
+    print -u2 "zsh-ai-cmd [lmstudio]: $error_msg"
+    return 1
+  fi
 
   print -r -- "$response" | command jq -re '.choices[0].message.content | fromjson | .command // empty' 2>/dev/null
 }

--- a/test-api.sh
+++ b/test-api.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 # test-api.sh - Validate API responses for format compliance
-# Usage: ./test-api.sh [--provider anthropic|openai|ollama|deepseek|gemini|copilot|claude-code]
+# Usage: ./test-api.sh [--provider anthropic|openai|ollama|lmstudio|deepseek|gemini|copilot|claude-code]
 
 set -uo pipefail
 
@@ -11,7 +11,7 @@ typeset -g ZSH_AI_CMD_PROVIDER=${ZSH_AI_CMD_PROVIDER:-'anthropic'}
 while [[ $# -gt 0 ]]; do
   case $1 in
     --provider|-p) ZSH_AI_CMD_PROVIDER=$2; shift 2 ;;
-    --help|-h) print "Usage: $0 [--provider anthropic|openai|ollama|deepseek|gemini|copilot|claude-code]"; exit 0 ;;
+    --help|-h) print "Usage: $0 [--provider anthropic|openai|ollama|lmstudio|deepseek|gemini|copilot|claude-code]"; exit 0 ;;
     *) print -u2 "Unknown option: $1"; exit 1 ;;
   esac
 done
@@ -33,6 +33,7 @@ source "${SCRIPT_DIR}/prompt.zsh"
 source "${SCRIPT_DIR}/providers/anthropic.zsh"
 source "${SCRIPT_DIR}/providers/openai.zsh"
 source "${SCRIPT_DIR}/providers/ollama.zsh"
+source "${SCRIPT_DIR}/providers/lmstudio.zsh"
 source "${SCRIPT_DIR}/providers/deepseek.zsh"
 source "${SCRIPT_DIR}/providers/gemini.zsh"
 source "${SCRIPT_DIR}/providers/copilot.zsh"
@@ -42,8 +43,8 @@ source "${SCRIPT_DIR}/providers/claude-code.zsh"
 get_api_key() {
   local provider=$ZSH_AI_CMD_PROVIDER
 
-  # Ollama, Copilot, and Claude Code don't need a key
-  [[ $provider == ollama || $provider == copilot || $provider == claude-code ]] && return 0
+  # LMStudio, Ollama, Copilot, and Claude Code don't need a key
+  [[ $provider == lmstudio || $provider == ollama || $provider == copilot || $provider == claude-code ]] && return 0
 
   local key_var="${(U)provider}_API_KEY"
   local keychain_name="${(e)ZSH_AI_CMD_KEYCHAIN_NAME:-${provider}-api-key}"
@@ -126,6 +127,7 @@ PWD: /tmp/test
     anthropic) _zsh_ai_cmd_anthropic_call "$input" "$prompt" ;;
     openai)    _zsh_ai_cmd_openai_call "$input" "$prompt" ;;
     ollama)    _zsh_ai_cmd_ollama_call "$input" "$prompt" ;;
+    lmstudio)  _zsh_ai_cmd_lmstudio_call "$input" "$prompt" ;;
     deepseek)  _zsh_ai_cmd_deepseek_call "$input" "$prompt" ;;
     gemini)    _zsh_ai_cmd_gemini_call "$input" "$prompt" ;;
     copilot)     _zsh_ai_cmd_copilot_call "$input" "$prompt" ;;
@@ -169,6 +171,7 @@ get_model_name() {
     anthropic) print "$ZSH_AI_CMD_ANTHROPIC_MODEL" ;;
     openai)    print "$ZSH_AI_CMD_OPENAI_MODEL" ;;
     ollama)    print "$ZSH_AI_CMD_OLLAMA_MODEL" ;;
+    lmstudio)  print "$ZSH_AI_CMD_LMSTUDIO_MODEL" ;;
     deepseek)  print "$ZSH_AI_CMD_DEEPSEEK_MODEL" ;;
     gemini)    print "$ZSH_AI_CMD_GEMINI_MODEL" ;;
     copilot)     print "$ZSH_AI_CMD_COPILOT_MODEL" ;;

--- a/zsh-ai-cmd.plugin.zsh
+++ b/zsh-ai-cmd.plugin.zsh
@@ -85,6 +85,7 @@ source "${0:a:h}/prompt.zsh"
 source "${0:a:h}/providers/anthropic.zsh"
 source "${0:a:h}/providers/openai.zsh"
 source "${0:a:h}/providers/ollama.zsh"
+source "${0:a:h}/providers/lmstudio.zsh"
 source "${0:a:h}/providers/deepseek.zsh"
 source "${0:a:h}/providers/gemini.zsh"
 source "${0:a:h}/providers/copilot.zsh"
@@ -208,6 +209,7 @@ _zsh_ai_cmd_call_api() {
     anthropic) _zsh_ai_cmd_anthropic_call "$input" "$prompt" ;;
     openai)    _zsh_ai_cmd_openai_call "$input" "$prompt" ;;
     ollama)    _zsh_ai_cmd_ollama_call "$input" "$prompt" ;;
+    lmstudio)  _zsh_ai_cmd_lmstudio_call "$input" "$prompt" ;;
     deepseek)  _zsh_ai_cmd_deepseek_call "$input" "$prompt" ;;
     gemini)    _zsh_ai_cmd_gemini_call "$input" "$prompt" ;;
     copilot)     _zsh_ai_cmd_copilot_call "$input" "$prompt" ;;
@@ -324,8 +326,8 @@ fi
 _zsh_ai_cmd_get_key() {
   local provider="${(L)ZSH_AI_CMD_PROVIDER}"  # Normalize provider to lowercase
 
-  # Ollama, Copilot, and Claude Code don't need a key
-  [[ $provider == ollama || $provider == copilot || $provider == claude-code ]] && return 0
+  # LMStudio, Ollama, Copilot, and Claude Code don't need a key
+  [[ $provider == lmstudio || $provider == ollama || $provider == copilot || $provider == claude-code ]] && return 0
 
   local key_var="${(U)provider}_API_KEY"
   local keychain_name="${(e)ZSH_AI_CMD_KEYCHAIN_NAME}"


### PR DESCRIPTION
This PR adds a new local inference provider for **LM Studio** (`providers/lmstudio.zsh`). 

### Why it is needed:
While LM Studio is widely used for running local LLMs, it uses the OpenAI-compatible API specification rather than the Ollama-specific format. Attempting to use the existing Ollama provider with LM Studio fails because:
1. **API Endpoints differ**: LM Studio uses `/v1/chat/completions` and `/v1/models` instead of `/api/chat` and `/api/tags`.
2. **Structured Outputs syntax differs**: LM Studio relies on the standard OpenAI `response_format` with `json_schema` wrapping, while Ollama expects a direct `format` object.
3. **Response Parsing differs**: The model's answer resides inside the `.choices[0].message.content` array path instead of `.message.content`.

### What this change does:
* Introduces a dedicated `lmstudio.zsh` provider.
* Configures default environment variables: `ZSH_AI_CMD_LMSTUDIO_MODEL` and `ZSH_AI_CMD_LMSTUDIO_HOST` (defaulting to `localhost:1234`).

## How I tested this

```
.zsh-ai-cmd git:(main) ✗ ./test-api.sh
Testing zsh-ai-cmd API responses
Provider: lmstudio
Model: google/gemma-4-e4b
================================

list running docker containers sorted by memory usage PASS
  -> docker ps --format "{{.Names}}	{{.Image}}	{{.MemUsage}}" | sort -k3
recursively find and replace foo with bar in all .txt files PASS
  -> find . -type f -name "*.txt" -exec grep -l "foo" {} + | xargs sed -i '' 's/foo/bar/g'
what time is it in tokyo                           PASS
  -> TZ="Asia/Tokyo" date "+%H:%M:%S %Z"
show disk usage by folder                          PASS
  -> du -h -d 1 | sort -hr
find empty directories                             PASS
  -> find . -type d -empty
find all files larger than 100mb and delete them   PASS
  -> find . -type f -size +100M -print -exec rm {} +
replace localhost with 127.0.0.1 in config.ini     PASS
  -> sed -i '' 's/localhost/127.0.0.1/g' config.ini
convert video.mp4 to animated gif                  PASS
  -> ffmpeg -i video.mp4 -vf "scale=320:-1,fps=10" output.gif
search for TODO in js files                        PASS
  -> grep -r "TODO" --include="*.js" .
list files                                         PASS
  -> ls -la
kill process on port 3000                          PASS
  -> lsof -t -i :3000 | xargs command kill -9
show modification time of README.md                PASS
  -> stat --file %Sm README.md
show the date 3 days ago                           PASS
  -> TZ='-3 day' command date '+%Y-%m-%d'
compress all jpg files in current directory        PASS
  -> ditto -c *.jpg
extract audio from movie.mkv as mp3                PASS
  -> ffmpeg -i movie.mkv -vn -acodec libmp3lame output.mp3
show me the last 5 git commits with stats          PASS
  -> git log --pretty=format:'* %h - %an, %ad : %s (%dr)' --date=short -n 5
consolidate git worktree into primary repo         PASS
  -> git worktree remove .
find python files modified today                   PASS
  -> find . -name "*.py" -mtime -1
create a tar.gz of the src directory               PASS
  -> tar -czf ../src.tar.gz src

================================
Results: 19 passed, 0 failed
```

## Trade-offs

<!-- Any drawbacks, alternatives considered, or edge cases worth noting? Write N/A if trivial. -->

- [x] I ran the relevant test scripts and tests pass
- [x] I tested manually in a live zsh session
- [x] My changes follow existing code conventions (`command` prefix, `_zsh_ai_cmd_` naming, etc.)
- [ ] I considered how this behaves when the API is down, slow, or returns unexpected output
